### PR TITLE
:green_heart: Upgrade node ver14 to 16

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -23,11 +23,11 @@ jobs:
     steps:
     # Runs a single command using the runners shell
       - name: Checkout
-        uses: actions/checkout@v2
-      - name: Use Node.js 14
-        uses: actions/setup-node@v1
+        uses: actions/checkout@v3
+      - name: Use Node.js 16
+        uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16.x
       - name: Build
         run: |
           yarn install && yarn run build

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -24,10 +24,10 @@ jobs:
     # Runs a single command using the runners shell
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Use Node.js 16
+      - name: Use Node.js 18
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Build
         run: |
           yarn install && yarn run build


### PR DESCRIPTION
gatsby-plugin-canonical-urls requires at least 18.  upgrade to 18 now.